### PR TITLE
Potential fix for build-time compilation error

### DIFF
--- a/Runtime/Values/BaseValue.cs
+++ b/Runtime/Values/BaseValue.cs
@@ -60,7 +60,7 @@
 #if UNITY_EDITOR
             return SerializationHelper.CreateCopy(originalValue);
 #else
-            return value;
+            return originalValue;
 #endif
         }
     }


### PR DESCRIPTION
This change is intended to address a [compilation error that crops up in BaseValue.cs](https://github.com/SolidAlloy/GenericScriptableArchitecture/issues/20) when building a project.  Looks like 'return value' should potentially be 'return originalValue' instead?

![image](https://user-images.githubusercontent.com/1191379/190554280-19629e65-4221-4819-b199-bc97151ac191.png)
